### PR TITLE
removed unused methods

### DIFF
--- a/jhotdraw-utils/src/main/java/org/jhotdraw/geom/ConvexHull.java
+++ b/jhotdraw-utils/src/main/java/org/jhotdraw/geom/ConvexHull.java
@@ -104,26 +104,6 @@ public class ConvexHull {
    * @param points
    * @return convex hull of the points
    */
-  public static List<Point> getConvexHull(List<Point> points) {
-    return Arrays.asList(getConvexHull(points.toArray(new Point[points.size()])));
-  }
-
-  /**
-   * Computes the convex hull from a set of points.
-   *
-   * @param points
-   * @return convex hull of the points
-   */
-  public static List<Point2D.Double> getConvexHull2D(List<Point2D.Double> points) {
-    return Arrays.asList(getConvexHull2D(points.toArray(new Point2D.Double[points.size()])));
-  }
-
-  /**
-   * Computes the convex hull from a set of points.
-   *
-   * @param points
-   * @return convex hull of the points
-   */
   public static Point[] getConvexHull(Point[] points) {
     // Quickly return if no work is needed
     if (points.length < 3) {


### PR DESCRIPTION
if provided a list, both methods getConvexHull() and getConvexHull2D() converts the list to an array , then they invoke the same method again, which will call the second constructor that takes and array as an input.

Since the lists are being already converted toArray() before calling getConvexHull() or getConvexHull2D(), they will never be called